### PR TITLE
Allow some projects to be publicly visible

### DIFF
--- a/app/assets/stylesheets/application/base.css.sass
+++ b/app/assets/stylesheets/application/base.css.sass
@@ -155,13 +155,13 @@ body
   form .checkbox-inner
     padding: 0 0 0 95px
   .col-box
-    width: 45%
+    width: 48%
     float: left
-    margin: 0 10% 0 0
+    margin: 0 4% 0 0
     select
       width: 110px
   .col-box2
-    width: 45%
+    width: 48%
     float: left
     select
       width: 110px
@@ -654,12 +654,12 @@ body .container h2 span.hide-responsive
   width: inherit
   text-align: inherit
   padding: 0
-span.show-responsive
+.show-responsive
   display: none
 @media screen and (max-width: 600px)
-  span.hide-responsive
+  .hide-responsive
     display: none
-  span.show-responsive
+  .show-responsive
     display: block
 
 table input.span1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,8 +4,13 @@ class ApplicationController < ActionController::Base
   before_filter :find_projects
 
   def find_projects
-    @projects = current_user.try(:projects) || []
+    @projects = (Project.public + (current_user.try(:projects) || [])).uniq
   end
+
+  def on_login_page?
+    %w(sessions registrations passwords).include? controller_name
+  end
+  helper_method :on_login_page?
 
   rescue_from CanCan::AccessDenied do |exception|
     if user_signed_in?

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -2,6 +2,7 @@ class ProjectsController < ApplicationController
   load_and_authorize_resource :except => :add_user_or_invite
 
   def index
+    redirect_to(login_url) and return unless user_signed_in? || @projects.any?
     respond_to do |format|
       format.html
       format.js { render partial: @projects }

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -42,6 +42,8 @@ class Ability
         end
       end
     else
+      can :read, Project, public: true
+
       can :create, User do |u|
         !User.any?
       end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,6 +11,8 @@ class Project < ActiveRecord::Base
 
   before_validation :create_hook_token, on: :create
 
+  scope :public, where(public: true)
+
   def self.build_all_nightly!
     Project.where(build_nightly: true).each do |project|
       build = project.builds.create

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,4 +1,4 @@
-- if user_signed_in?
+- unless on_login_page?
   %header
     %h1.small-logo
       %a{:href =>"/", :title =>"Bennett - Go to dashboard"}
@@ -11,12 +11,22 @@
       - if user_signed_in?
         %li.logout
           = link_to destroy_user_session_path, :method => :delete do
-            %span.hide-responsive Log Out
+            %span.hide-responsive Log out
+            %span.show-responsive
+              %i.icon-off.icon-white
+      - else
+        %li.logout
+          = link_to new_user_session_path do
+            %span.hide-responsive Login
             %span.show-responsive
               %i.icon-off.icon-white
     .clear
 - else
   %header
+    - if @projects.any?
+      %ul.nav.nav-pills
+        %li.hide-responsive= link_to "Back to dashboard", projects_path
+        %li.show-responsive= link_to "Dashboard", projects_path
     %h1.logo
       %a{:href =>"/", :title =>"Bennett - Go to homepage"}
         %span.hide Bennett

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     = javascript_include_tag :application
     = csrf_meta_tags
     %meta{:name => "viewport", :content => "width=device-width, initial-scale=0.5, maximum-scale=2"}
-  %body{:class => user_signed_in? ? 'connection-mode' : ''}
+  %body{:class => on_login_page? ? '' : 'connection-mode'}
     .container
       = render partial: 'layouts/header', locals: { projects: @projects, current_project: @project }
       .content

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -23,5 +23,11 @@
     = form.label :build_nightly, :class => "checkbox-style1"
     .clear
     %span.help-block Build every night at 1:00 regardless of activity
+  - form.labeled_input :public do
+    .input.checkbox-btn
+      = form.check_box :public
+    = form.label :public, :class => "checkbox-style1"
+    .clear
+    %span.help-block Make this project publicly visible
   .input
     = form.submit "Save the project", :class => "btn"

--- a/app/views/projects/_settings.html.haml
+++ b/app/views/projects/_settings.html.haml
@@ -17,8 +17,11 @@
   %strong Recentizer&#153; 3000 Pro:
   = @project.recentizer? ? 'On' : 'Off'
 %p
-  %strong Build nightly:
+  %strong Nightly build:
   = @project.build_nightly? ? 'On' : 'Off'
+%p
+  %strong Visibility:
+  = @project.public? ? 'Public' : 'Private'
 %p
   %strong Post-Receive URL for Git hook:
   = project_builds_url(@project, format: :json, t: @project.hook_token)

--- a/db/migrate/20120717114259_add_public_to_projects.rb
+++ b/db/migrate/20120717114259_add_public_to_projects.rb
@@ -1,0 +1,5 @@
+class AddPublicToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :public, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120707154628) do
+ActiveRecord::Schema.define(:version => 20120717114259) do
 
   create_table "builds", :force => true do |t|
     t.integer  "project_id"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(:version => 20120707154628) do
     t.datetime "updated_at",                       :null => false
     t.string   "hook_token"
     t.boolean  "build_nightly", :default => false
+    t.boolean  "public",        :default => false
   end
 
   create_table "results", :force => true do |t|


### PR DESCRIPTION
#21

I changed the redirect mechanism so that when you are not logged in but public projects are available, you are taken to the projects page, from which you can login using a button I added.

The setting itself is a simple checkbox in the project settings. Unregistered user cannot do anything except read.
