### PR TITLE
Fix for issue #41 build branch <> master

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -73,7 +73,7 @@ class Build < ActiveRecord::Base
     git = Git.open(project.folder_path)
     git.reset_hard
     git.checkout(project.branch)
-    git.pull
+    git.lib.send(:command, 'pull')
     git.checkout(commit_hash)
   end
 


### PR DESCRIPTION
This works for me. Git pull seems to be borked: https://github.com/schacon/ruby-git/issues/32
